### PR TITLE
Add moon phase label column to tides view

### DIFF
--- a/Log/Log/Scripts/Tides.js
+++ b/Log/Log/Scripts/Tides.js
@@ -169,12 +169,14 @@ function renderMonthCard(year, month, springDays) {
         var reason = springInfo && springInfo.reason ? springInfo.reason : '';
         var phase = springInfo ? springInfo.phase : null;
         var phaseIcon = getPhaseIcon(phase);
+        var phaseLabel = getPhaseLabel(phase);
         var springLabel = isSpring ? 'Stórstraumur' : '';
         dayRows.push(
             '<tr class="tide-day' + (isSpring ? ' tide-day--spring' : '') + '" title="' + escapeHtml(reason) + '">' +
             '<td class="tide-day__date">' + monthNames[month - 1] + ' ' + day + '</td>' +
             '<td class="tide-day__weekday">' + weekday + '</td>' +
             '<td class="tide-day__icon">' + phaseIcon + '</td>' +
+            '<td class="tide-day__phase">' + phaseLabel + '</td>' +
             '<td class="tide-day__spring">' + springLabel + '</td>' +
             '</tr>'
         );
@@ -184,6 +186,15 @@ function renderMonthCard(year, month, springDays) {
         '<div class="tide-month">' +
         '<div class="tide-month__header">' + monthNames[month - 1] + '</div>' +
         '<table class="tide-month__table">' +
+        '<thead>' +
+        '<tr>' +
+        '<th scope="col">Date</th>' +
+        '<th scope="col">Weekday</th>' +
+        '<th scope="col">Phase</th>' +
+        '<th scope="col">Moon</th>' +
+        '<th scope="col">Spring</th>' +
+        '</tr>' +
+        '</thead>' +
         '<tbody>' + dayRows.join('') + '</tbody>' +
         '</table>' +
         '</div>'
@@ -199,6 +210,16 @@ function getPhaseIcon(phase) {
     }
     if (phase === 2 || phase === 'FullMoon') {
         return '<span class="tide-day__icon-marker" aria-label="Full moon"><span class="fa fa-moon-o" aria-hidden="true"></span></span>';
+    }
+    return '';
+}
+
+function getPhaseLabel(phase) {
+    if (phase === 0 || phase === 'NewMoon') {
+        return 'New moon';
+    }
+    if (phase === 2 || phase === 'FullMoon') {
+        return 'Full moon';
     }
     return '';
 }


### PR DESCRIPTION
### Motivation
- Provide a clear textual indicator in the tides month table when a day is a new moon or full moon to complement the existing icon.

### Description
- Updated `Log/Log/Scripts/Tides.js` to add a new table header and a column that displays moon phase text next to the icon for each day.
- Added a `getPhaseLabel` helper that returns `New moon` or `Full moon` for recognized phase values and integrated it into the row rendering logic.
- Kept existing `getPhaseIcon` behavior and preserved the existing spring tide highlighting and row title logic.

### Testing
- Started a local server with `python -m http.server` and ran a Playwright script to load `Tides.html` and capture a screenshot, and the script completed successfully.
- No unit tests or CI jobs were executed for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69715c5cf39c832da8d669d82842863d)