### PR TITLE
Add moon imagery to Tides page

### DIFF
--- a/Log/Log/Scripts/style.css
+++ b/Log/Log/Scripts/style.css
@@ -334,6 +334,42 @@ body
     text-shadow: 0 0 6px rgba(177, 156, 255, 0.45);
 }
 
+.tide-moon-gallery {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    margin-top: 10px;
+    flex-wrap: wrap;
+}
+
+.tide-moon-card {
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+    padding: 10px 12px;
+    border-radius: 12px;
+    background: linear-gradient(135deg, rgba(12, 18, 42, 0.9), rgba(25, 33, 67, 0.9));
+    color: #f5f5f5;
+    box-shadow: 0 8px 18px rgba(0, 0, 0, 0.25);
+}
+
+.tide-moon-card img {
+    width: 120px;
+    height: 120px;
+    border-radius: 50%;
+    object-fit: cover;
+    border: 2px solid rgba(255, 255, 255, 0.2);
+}
+
+.tide-moon-card figcaption {
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.8px;
+    color: #d8dcf7;
+}
+
 .tide-day__icon .fa-moon-o {
     color: #8fe7ff;
     text-shadow: 0 0 6px rgba(143, 231, 255, 0.4);

--- a/Log/Log/Tides.html
+++ b/Log/Log/Tides.html
@@ -38,6 +38,16 @@
                         <span class="fa fa-moon-o tide-moon-icon" aria-hidden="true" title="Full moon"></span>
                         <span class="sr-only">Full moon</span>
                         <span class="calendar-menu__subtitle">Spring tide windows for the selected year (UTC).</span>
+                        <div class="tide-moon-gallery" aria-label="Moon phases">
+                            <figure class="tide-moon-card">
+                                <img src="images/full-moon.svg" alt="Full moon glowing in a night sky">
+                                <figcaption>Full moon</figcaption>
+                            </figure>
+                            <figure class="tide-moon-card">
+                                <img src="images/new-moon.svg" alt="New moon with a soft halo">
+                                <figcaption>New moon</figcaption>
+                            </figure>
+                        </div>
                     </div>
                     <div class="calendar-menu__actions btn-group btn-group-sm" role="group" aria-label="Navigation">
                         <button class="btn btn-default" onclick="location.href='CalFull.html'">Fishing calendar</button>

--- a/Log/Log/images/full-moon.svg
+++ b/Log/Log/images/full-moon.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 600" role="img" aria-labelledby="title desc">
+  <title id="title">Full Moon</title>
+  <desc id="desc">A glowing full moon with subtle crater highlights.</desc>
+  <defs>
+    <radialGradient id="moonGlow" cx="50%" cy="40%" r="60%">
+      <stop offset="0%" stop-color="#fff6c7" />
+      <stop offset="55%" stop-color="#f5e6a1" />
+      <stop offset="100%" stop-color="#e8d27c" />
+    </radialGradient>
+    <radialGradient id="crater" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#f0d98e" stop-opacity="0.7" />
+      <stop offset="100%" stop-color="#d9c27b" stop-opacity="0.2" />
+    </radialGradient>
+  </defs>
+  <rect width="600" height="600" fill="#0b1026" />
+  <circle cx="300" cy="300" r="220" fill="url(#moonGlow)" />
+  <circle cx="230" cy="240" r="45" fill="url(#crater)" />
+  <circle cx="370" cy="210" r="30" fill="url(#crater)" />
+  <circle cx="320" cy="340" r="65" fill="url(#crater)" />
+  <circle cx="210" cy="360" r="25" fill="url(#crater)" />
+  <circle cx="380" cy="380" r="35" fill="url(#crater)" />
+</svg>

--- a/Log/Log/images/new-moon.svg
+++ b/Log/Log/images/new-moon.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 600" role="img" aria-labelledby="title desc">
+  <title id="title">New Moon</title>
+  <desc id="desc">A dark new moon with a soft halo against a night sky.</desc>
+  <defs>
+    <radialGradient id="night" cx="50%" cy="50%" r="70%">
+      <stop offset="0%" stop-color="#0f1736" />
+      <stop offset="100%" stop-color="#05070f" />
+    </radialGradient>
+    <radialGradient id="halo" cx="50%" cy="50%" r="60%">
+      <stop offset="0%" stop-color="#11172e" stop-opacity="0" />
+      <stop offset="65%" stop-color="#2b3a6b" stop-opacity="0.35" />
+      <stop offset="100%" stop-color="#0b1020" stop-opacity="0.9" />
+    </radialGradient>
+  </defs>
+  <rect width="600" height="600" fill="url(#night)" />
+  <circle cx="300" cy="300" r="220" fill="#07070b" />
+  <circle cx="300" cy="300" r="250" fill="url(#halo)" />
+  <circle cx="240" cy="250" r="6" fill="#ffffff" opacity="0.45" />
+  <circle cx="360" cy="220" r="4" fill="#ffffff" opacity="0.35" />
+  <circle cx="330" cy="380" r="5" fill="#ffffff" opacity="0.4" />
+</svg>


### PR DESCRIPTION
### Motivation
- Improve the Tides page header by visually indicating moon phases to complement tidal information and provide a more engaging UI.

### Description
- Inserted a moon gallery markup into `Log/Log/Tides.html` that shows full and new moon cards with captions and accessible `alt` text.
- Added styles for the gallery and cards in `Log/Log/Scripts/style.css` under the `.tide-moon-gallery` and `.tide-moon-card` rules to match the site theme.
- Added two inline SVG assets at `Log/Log/images/full-moon.svg` and `Log/Log/images/new-moon.svg` used by the gallery.

### Testing
- Rendered the updated page via a local HTTP server and captured a headless browser screenshot using Playwright (output saved as `artifacts/tides-moons.png`), which completed successfully.
- No unit or integration tests were applicable to this static UI change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972773c3b34832d9215815862792691)