### PR TITLE
Make Iceland fishing map full-page

### DIFF
--- a/Log/Log/IcelandFishingMap.html
+++ b/Log/Log/IcelandFishingMap.html
@@ -18,70 +18,68 @@
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
             integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
 </head>
-<body>
+<body class="map-full-page">
     <a class="home-link" href="CalFull.html" aria-label="Home">
         <span class="fa fa-home" aria-hidden="true"></span>
     </a>
 
-    <div class="sub-content-container">
-        <div class="sub-content">
-            <div class="panel panel-default main-panel">
-                <div class="panel-heading calendar-menu">
-                    <div class="calendar-menu__title">
-                        <span class="calendar-menu__title-text"><b>Iceland fishing map</b></span>
-                        <span class="calendar-menu__subtitle">Track where you've fished and what is still on the list.</span>
-                    </div>
-                    <div class="calendar-menu__actions btn-group btn-group-sm" role="group" aria-label="Navigation">
-                        <button class="btn btn-default" onclick="location.href='CalFull.html'">Fishing calendar</button>
-                        <button class="btn btn-default" onclick="location.href='FishingPlaces.html'">Fishing places list</button>
-                        <button class="btn btn-default" onclick="location.href='FishingPlaceSpots.html'">Fishing place spots</button>
-                        <button class="btn btn-default" onclick="location.href='FishingPlaceWishlist.html'">Fishing place wishlist</button>
-                        <button class="btn btn-default active" onclick="location.href='IcelandFishingMap.html'">Iceland map</button>
-                        <button class="btn btn-default" onclick="location.href='WeatherHistory.html'">Weather history</button>
-                        <button class="btn btn-default" onclick="location.href='Tides.html'">Tides</button>
-                        <button class="btn btn-default" onclick="location.href='SuggestedFishingTrips.html'">Suggested trips</button>
-                        <button class="btn btn-default" onclick="location.href='fishingnews.html'">Fishing news</button>
-                    </div>
-                </div>
-                <div class="panel-body">
-                    <div class="row" style="margin-bottom: 15px;">
-                        <div class="col-sm-6">
-                            <div class="panel panel-info">
-                                <div class="panel-heading">
-                                    <b>Fishing progress</b>
-                                </div>
-                                <div class="panel-body">
-                                    <p style="margin-bottom: 5px;">
-                                        <span class="label label-success">Visited</span>
-                                        <span id="visitedCount" class="badge">0</span>
-                                    </p>
-                                    <p style="margin-bottom: 0;">
-                                        <span class="label label-warning">Still to go</span>
-                                        <span id="remainingCount" class="badge">0</span>
-                                    </p>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-sm-6">
-                            <div class="panel panel-default">
-                                <div class="panel-heading">
-                                    <b>Legend</b>
-                                </div>
-                                <div class="panel-body">
-                                    <p style="margin-bottom: 8px;">
-                                        <span style="display:inline-block; width:12px; height:12px; border-radius:50%; background:#2ecc71; margin-right:6px;"></span>
-                                        Visited fishing spots
-                                    </p>
-                                    <p style="margin-bottom: 0;">
-                                        <span style="display:inline-block; width:12px; height:12px; border-radius:50%; background:#f39c12; margin-right:6px;"></span>
-                                        Wishlist destinations
-                                    </p>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+    <div id="icelandMap" class="full-page-map"></div>
 
-                    <div id="icelandMap" style="height: 520px; border-radius: 6px; border: 1px solid #ddd;"></div>
+    <div class="map-overlay">
+        <div class="panel panel-default map-panel">
+            <div class="panel-heading calendar-menu">
+                <div class="calendar-menu__title">
+                    <span class="calendar-menu__title-text"><b>Iceland fishing map</b></span>
+                    <span class="calendar-menu__subtitle">Track where you've fished and what is still on the list.</span>
+                </div>
+                <div class="calendar-menu__actions btn-group btn-group-sm" role="group" aria-label="Navigation">
+                    <button class="btn btn-default" onclick="location.href='CalFull.html'">Fishing calendar</button>
+                    <button class="btn btn-default" onclick="location.href='FishingPlaces.html'">Fishing places list</button>
+                    <button class="btn btn-default" onclick="location.href='FishingPlaceSpots.html'">Fishing place spots</button>
+                    <button class="btn btn-default" onclick="location.href='FishingPlaceWishlist.html'">Fishing place wishlist</button>
+                    <button class="btn btn-default active" onclick="location.href='IcelandFishingMap.html'">Iceland map</button>
+                    <button class="btn btn-default" onclick="location.href='WeatherHistory.html'">Weather history</button>
+                    <button class="btn btn-default" onclick="location.href='Tides.html'">Tides</button>
+                    <button class="btn btn-default" onclick="location.href='SuggestedFishingTrips.html'">Suggested trips</button>
+                    <button class="btn btn-default" onclick="location.href='fishingnews.html'">Fishing news</button>
+                </div>
+            </div>
+            <div class="panel-body">
+                <div class="row">
+                    <div class="col-sm-6">
+                        <div class="panel panel-info">
+                            <div class="panel-heading">
+                                <b>Fishing progress</b>
+                            </div>
+                            <div class="panel-body">
+                                <p style="margin-bottom: 5px;">
+                                    <span class="label label-success">Visited</span>
+                                    <span id="visitedCount" class="badge">0</span>
+                                </p>
+                                <p style="margin-bottom: 0;">
+                                    <span class="label label-warning">Still to go</span>
+                                    <span id="remainingCount" class="badge">0</span>
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-sm-6">
+                        <div class="panel panel-default">
+                            <div class="panel-heading">
+                                <b>Legend</b>
+                            </div>
+                            <div class="panel-body">
+                                <p style="margin-bottom: 8px;">
+                                    <span style="display:inline-block; width:12px; height:12px; border-radius:50%; background:#2ecc71; margin-right:6px;"></span>
+                                    Visited fishing spots
+                                </p>
+                                <p style="margin-bottom: 0;">
+                                    <span style="display:inline-block; width:12px; height:12px; border-radius:50%; background:#f39c12; margin-right:6px;"></span>
+                                    Wishlist destinations
+                                </p>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>

--- a/Log/Log/Scripts/style.css
+++ b/Log/Log/Scripts/style.css
@@ -2,6 +2,37 @@ body {
     margin: 0;
 }
 
+body.map-full-page {
+    height: 100vh;
+    overflow: hidden;
+}
+
+.full-page-map {
+    position: fixed;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    border: none;
+}
+
+.map-overlay {
+    position: fixed;
+    top: 60px;
+    left: 16px;
+    right: 16px;
+    z-index: 900;
+    pointer-events: none;
+}
+
+.map-overlay .panel,
+.map-overlay .btn {
+    pointer-events: auto;
+}
+
+.map-panel {
+    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
+}
+
 .home-link {
     position: fixed;
     top: 12px;
@@ -587,4 +618,3 @@ body {
 .tide-month__table td.tide-day__spring {
     padding-left: 20px;
 }
-


### PR DESCRIPTION
### Motivation
- The Iceland fishing map should fill the browser viewport so the map is the primary focus and usable at full size. 
- Overlay the existing controls and summary panel on top of the map so the UI remains accessible without shrinking the map.

### Description
- Updated `Log/Log/IcelandFishingMap.html` to add `body.map-full-page`, move `#icelandMap` to a full-page container and wrap the previous panels into a floating `.map-overlay` panel so controls are overlaid on the map.
- Added layout and interaction CSS in `Log/Log/Scripts/style.css` including `.map-full-page`, `.full-page-map`, `.map-overlay`, pointer-events adjustments to allow UI interaction over the map, and a `.map-panel` shadow for readability.
- Kept the Leaflet map initialization and markers unchanged; only DOM structure and styling were modified to achieve the full-viewport layout.

### Testing
- Served the `Log/Log` folder via `python -m http.server 8000` and verified the page in an automated browser session with Playwright which captured a screenshot artifact at `artifacts/iceland-map-full.png` (succeeded).
- Verified that the map renders and overlay controls are interactive in the captured test run (visual/functional check via screenshot).
- No unit tests were required since this change is static HTML/CSS layout only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973acb8e160832db89ff25288d395ad)