### PR TITLE
Align suggested trip season to April–October

### DIFF
--- a/FishingLogApi/FishingLogApi/Controllers/SuggestedFishingTripsController.cs
+++ b/FishingLogApi/FishingLogApi/Controllers/SuggestedFishingTripsController.cs
@@ -209,16 +209,16 @@ public class SuggestedFishingTripsController : ControllerBase
 
     private static SeasonRange GetUpcomingSeasonRange(DateTime today)
     {
-        var seasonYear = today.Month > 11 ? today.Year + 1 : today.Year;
+        var seasonYear = today.Month > 10 ? today.Year + 1 : today.Year;
         var seasonStart = new DateTime(seasonYear, 4, 1);
-        var seasonEnd = new DateTime(seasonYear, 11, 30);
+        var seasonEnd = new DateTime(seasonYear, 10, 31);
 
         return new SeasonRange(seasonYear, seasonStart, seasonEnd);
     }
 
     private static bool IsEntryInSeason(SuggestionEntry entry, SeasonRange seasonRange)
     {
-        if (entry.Month < 4 || entry.Month > 11)
+        if (entry.Month < 4 || entry.Month > 10)
         {
             return false;
         }
@@ -261,7 +261,7 @@ public class SuggestedFishingTripsController : ControllerBase
                 PlaceId = placeId,
                 PlaceName = placeMap[placeId],
                 Date = date,
-                Reason = "Suggested for the upcoming April-November season based on available fishing places.",
+                Reason = "Suggested for the upcoming April-October season based on available fishing places.",
                 TripCount = 0,
                 NewsCount = 0
             });


### PR DESCRIPTION
### Motivation
- The suggestion logic must use the April–October fishing season (both months included) so generated trip suggestions match the requested season window. 
- Ensure the upcoming season is calculated correctly when the current date is in November or December.

### Description
- Change season year rollover in `GetUpcomingSeasonRange` to advance the year when `today.Month > 10` so November triggers the next season calculation. 
- Set the season end to `new DateTime(seasonYear, 10, 31)` to limit the season to October. 
- Restrict `IsEntryInSeason` to only accept months 4–10 and update the fallback suggestion `Reason` text to say "April-October".

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69810464b1e0832dbe90a46a5b581147)